### PR TITLE
Use longer timeout, fixing entering RAW1 on macOS

### DIFF
--- a/PirateSWD.py
+++ b/PirateSWD.py
@@ -4,7 +4,7 @@ from SWDErrors import *
 
 class PirateSWD:
     def __init__ (self, f = "/dev/bus_pirate"):
-        self.port = serial.Serial(port = f, baudrate = 115200, timeout = 0.01)
+        self.port = serial.Serial(port = f, baudrate = 115200, timeout = 0.1)
         self.resetBP()
         self.sendBytes([0xFF] * 8)
         self.sendBytes([0x79, 0xE7])

--- a/PirateSWD.py
+++ b/PirateSWD.py
@@ -4,7 +4,7 @@ from SWDErrors import *
 
 class PirateSWD:
     def __init__ (self, f = "/dev/bus_pirate"):
-        self.port = serial.Serial(port = f, baudrate = 115200, timeout = 0.1)
+        self.port = serial.Serial(port = f, baudrate = 115200, timeout = 1)
         self.resetBP()
         self.sendBytes([0xFF] * 8)
         self.sendBytes([0x79, 0xE7])


### PR DESCRIPTION
Trying to get this working on my system (macOS High Sierra), stepping through the code, it was able to send 0x0f and read BBIO1 (entered binary mode), but then it would always fail to enter RAW1 mode:

```
$ python flashSTM32.py  
Traceback (most recent call last):
  File "flashSTM32.py", line 41, in <module>
    main()
  File "flashSTM32.py", line 18, in main
    busPirate = PirateSWD("/dev/tty.usbserial")
  File "pirate-swd/PirateSWD.py", line 8, in __init__
    self.resetBP()
  File "pirate-swd/PirateSWD.py", line 22, in resetBP
    raise SWDInitError("error initializing bus pirate")
SWDErrors.SWDInitError: error initializing bus pirate
```

Tracked it down to reading an empty string here:

```python
        if self.port.read(4) != "RAW1":
            raise SWDInitError("error initializing bus pirate")
```

because the timeout 0.01 is too short. After changing it to 0.1 in this pull request, able to read RAW1 successfully.